### PR TITLE
Fix typo in 4-distributed-scheduler.ipynb

### DIFF
--- a/4-distributed-scheduler.ipynb
+++ b/4-distributed-scheduler.ipynb
@@ -150,7 +150,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Retreieve cluster logs\n",
+    "# Retrieve cluster logs\n",
     "cluster.get_logs()"
    ]
   },


### PR DESCRIPTION
Fixes a minor typo in notebook `4-distributed-scheduler.ipynb`

Original:
```python
# Retreieve cluster logs
cluster.get_logs()
```

Fix:
```python
# Retrieve cluster logs
cluster.get_logs()
```
