### PR TITLE
Fixed a Typo in the 1st Notebook (Dask Overview)

### DIFF
--- a/1-overview.ipynb
+++ b/1-overview.ipynb
@@ -50,7 +50,7 @@
     "\n",
     "From a high level, Dask is comprised of two main components:\n",
     "\n",
-    "1. **Dask collections** which extend common interfaces like NumPy, pandas, and Python iterators to larger-than-memoty or distributed environments by creating *task graphs*\n",
+    "1. **Dask collections** which extend common interfaces like NumPy, pandas, and Python iterators to larger-than-memory or distributed environments by creating *task graphs*\n",
     "2. **Schedulers** which compute task graphs produced by Dask collections in parallel\n",
     "\n",
     "<img src=\"images/dask-overview.png\"\n",


### PR DESCRIPTION
`memoty` -> `memory`